### PR TITLE
Parametrize namespace with envsubst

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,20 @@ Kubernetes/OpenShift manifests are provided under the `k8s/` directory. Apply th
 3. `k8s/rbac/` – roles and bindings required for the pipeline service account.
 4. `k8s/deployment.yaml`, `k8s/service.yaml` and `k8s/route.yaml` – deploy the application and expose it via a route.
 
-Adjust the namespace in the manifests if necessary, then run:
+Before applying the manifests set a namespace variable and substitute it when
+applying. For a single file this looks like:
 
 ```bash
-kubectl apply -f k8s/
+export NAMESPACE=student05
+envsubst < k8s/deployment.yaml | oc apply -f -
+```
+
+To process multiple files you can loop over them:
+
+```bash
+for f in k8s/*.yaml k8s/rbac/*.yaml; do
+  envsubst < "$f" | oc apply -f -
+done
 ```
 
 ## Tekton and Shipwright Pipelines

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: java-webapp
-  namespace: student01
+  namespace: {{NAMESPACE}}
   labels:
     app: java-webapp
 spec:
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: java-webapp
           # student’s namespace/project will be set at apply time
-          image: image-registry.openshift-image-registry.svc:5000/student01/java-webapp:latest
+          image: image-registry.openshift-image-registry.svc:5000/{{NAMESPACE}}/java-webapp:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/k8s/java-webapp-imagestream.yaml
+++ b/k8s/java-webapp-imagestream.yaml
@@ -2,6 +2,6 @@ apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: java-webapp
-  namespace: student01
+  namespace: {{NAMESPACE}}
   labels:
     app: java-webapp

--- a/k8s/rbac/pipeline-app-binding.yaml
+++ b/k8s/rbac/pipeline-app-binding.yaml
@@ -3,11 +3,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: pipeline-deploy-binding
-  namespace: student01
+  namespace: {{NAMESPACE}}
 subjects:
   - kind: ServiceAccount
     name: pipeline
-    namespace: student01
+    namespace: {{NAMESPACE}}
 roleRef:
   kind: Role
   name: pipeline-deploy-permissions

--- a/k8s/rbac/pipeline-app-role.yaml
+++ b/k8s/rbac/pipeline-app-role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: pipeline-deploy-permissions
-  namespace: student01          # or parameterize per-student
+  namespace: {{NAMESPACE}}          # or parameterize per-student
 rules:
   - apiGroups: [""]
     resources: ["services"]

--- a/shipwright/build/build.yaml
+++ b/shipwright/build/build.yaml
@@ -2,7 +2,7 @@ apiVersion: shipwright.io/v1alpha1
 kind: Build
 metadata:
   name: java-webapp-build
-  namespace: student01
+  namespace: {{NAMESPACE}}
 spec:
   source:
     type: Git
@@ -13,4 +13,4 @@ spec:
     name: buildah-shipwright-managed-push
     kind: ClusterBuildStrategy
   output:
-    image: image-registry.openshift-image-registry.svc:5000/student01/java-webapp:latest
+    image: image-registry.openshift-image-registry.svc:5000/{{NAMESPACE}}/java-webapp:latest

--- a/shipwright/build/buildrun.yaml
+++ b/shipwright/build/buildrun.yaml
@@ -2,7 +2,7 @@ apiVersion: shipwright.io/v1beta1
 kind: BuildRun
 metadata:
   generateName: java-webapp-buildrun-
-  namespace: student01
+  namespace: {{NAMESPACE}}
 spec:
   build:
     name: java-webapp-build

--- a/tekton/pipeline-run.yaml
+++ b/tekton/pipeline-run.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
   name: java-webapp-run
-  namespace: student01        # <-- your student’s project
+  namespace: {{NAMESPACE}}        # <-- your student’s project
 spec:
   pipelineRef:
     name: java-webapp-pipeline
@@ -14,7 +14,7 @@ spec:
     - name: build-name
       value: java-webapp-build   # matches your Shipwright Build metadata.name
     - name: namespace
-      value: student01           # target for both Shipwright and deploy
+      value: {{NAMESPACE}}           # target for both Shipwright and deploy
   workspaces:
     - name: source
       persistentVolumeClaim:


### PR DESCRIPTION
## Summary
- use `{{NAMESPACE}}` placeholder in Kubernetes, Tekton and Shipwright manifests
- document how to export a namespace and substitute it via `envsubst`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685095177488832db79d7a3b7e3c5f8c